### PR TITLE
CI/CD workflows + unit tests (18 passing)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: maven
+
+      - name: Build and test
+        run: ./mvnw -B verify --file pom.xml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,6 +82,10 @@ jobs:
           RDS_ADDRESS=$(aws rds describe-db-instances \
             --db-instance-identifier ${{ env.EKS_CLUSTER_NAME }}-mysql \
             --query 'DBInstances[0].Endpoint.Address' --output text)
+          if [ -z "$RDS_ADDRESS" ] || [ "$RDS_ADDRESS" = "None" ]; then
+            echo "ERROR: Could not resolve RDS address"
+            exit 1
+          fi
           echo "rds_address=${RDS_ADDRESS}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy with Helm

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,98 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  EKS_CLUSTER_NAME: vibevault-dev
+  ECR_REPO: vibevault-dev/payment-gateway
+  HELM_RELEASE: paymentgateway
+  HELM_CHART_PATH: helm/paymentgateway
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    environment: dev
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      image_repo: ${{ steps.meta.outputs.image_repo }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          IMAGE_TAG="${GITHUB_SHA::8}"
+          REGISTRY="${{ steps.ecr-login.outputs.registry }}"
+          IMAGE_REPO="${REGISTRY}/${{ env.ECR_REPO }}"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.image_tag }} .
+          docker tag ${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.image_tag }} ${{ steps.meta.outputs.image_repo }}:latest
+          docker push ${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.image_tag }}
+          docker push ${{ steps.meta.outputs.image_repo }}:latest
+
+  deploy:
+    name: Deploy to EKS
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: dev
+    concurrency:
+      group: deploy-paymentgateway-dev
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubectl
+        run: aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+
+      - name: Get RDS address
+        id: params
+        run: |
+          RDS_ADDRESS=$(aws rds describe-db-instances \
+            --db-instance-identifier ${{ env.EKS_CLUSTER_NAME }}-mysql \
+            --query 'DBInstances[0].Endpoint.Address' --output text)
+          echo "rds_address=${RDS_ADDRESS}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install ${{ env.HELM_RELEASE }} ${{ env.HELM_CHART_PATH }} \
+            -n vibevault --create-namespace \
+            --set image.repository=${{ needs.build-and-push.outputs.image_repo }} \
+            --set image.tag=${{ needs.build-and-push.outputs.image_tag }} \
+            --set config.kafkaBootstrapServers="kafka:9092" \
+            --set-string config.dbUrl="jdbc:mysql://${{ steps.params.outputs.rds_address }}:3306/paymentgateway?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" \
+            --wait --timeout 300s
+
+      - name: Verify deployment
+        run: kubectl rollout status deployment/${{ env.HELM_RELEASE }} -n vibevault --timeout=180s

--- a/src/test/java/com/vibevault/paymentgateway/controllers/PaymentControllerTest.java
+++ b/src/test/java/com/vibevault/paymentgateway/controllers/PaymentControllerTest.java
@@ -1,0 +1,96 @@
+package com.vibevault.paymentgateway.controllers;
+
+import com.vibevault.paymentgateway.exceptions.PaymentNotFoundException;
+import com.vibevault.paymentgateway.models.Payment;
+import com.vibevault.paymentgateway.models.PaymentStatus;
+import com.vibevault.paymentgateway.security.SecurityConfig;
+import com.vibevault.paymentgateway.services.PaymentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentController.class)
+@Import(SecurityConfig.class)
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PaymentService paymentService;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    private Payment buildPayment(UUID id, UUID orderId) {
+        Payment payment = Payment.builder()
+                .orderId(orderId)
+                .userId("user-1")
+                .amount(new BigDecimal("999.98"))
+                .currency("INR")
+                .status(PaymentStatus.PENDING)
+                .gateway("RAZORPAY")
+                .gatewayPaymentLink("https://rzp.io/test")
+                .build();
+        payment.setId(id);
+        return payment;
+    }
+
+    @Test
+    void getPaymentByOrderId_returnsPayment() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        UUID paymentId = UUID.randomUUID();
+        Payment payment = buildPayment(paymentId, orderId);
+        when(paymentService.getPaymentByOrderId(orderId, "user-1")).thenReturn(payment);
+
+        mockMvc.perform(get("/payments/order/{orderId}", orderId)
+                        .with(jwt().jwt(j -> j.subject("user-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paymentId").value(paymentId.toString()))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.gateway").value("RAZORPAY"));
+    }
+
+    @Test
+    void getPaymentById_returnsPayment() throws Exception {
+        UUID paymentId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        Payment payment = buildPayment(paymentId, orderId);
+        when(paymentService.getPaymentById(paymentId, "user-1")).thenReturn(payment);
+
+        mockMvc.perform(get("/payments/{paymentId}", paymentId)
+                        .with(jwt().jwt(j -> j.subject("user-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paymentId").value(paymentId.toString()));
+    }
+
+    @Test
+    void getPayment_notFound_returns404() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        when(paymentService.getPaymentByOrderId(orderId, "user-1"))
+                .thenThrow(new PaymentNotFoundException("Payment not found for order: " + orderId));
+
+        mockMvc.perform(get("/payments/order/{orderId}", orderId)
+                        .with(jwt().jwt(j -> j.subject("user-1"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getPayment_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/payments/order/" + UUID.randomUUID()))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/vibevault/paymentgateway/services/PaymentServiceTest.java
+++ b/src/test/java/com/vibevault/paymentgateway/services/PaymentServiceTest.java
@@ -1,0 +1,222 @@
+package com.vibevault.paymentgateway.services;
+
+import com.vibevault.paymentgateway.dtos.PaymentLinkRequest;
+import com.vibevault.paymentgateway.dtos.PaymentLinkResponse;
+import com.vibevault.paymentgateway.dtos.PaymentTransitionResult;
+import com.vibevault.paymentgateway.exceptions.InvalidPaymentStateException;
+import com.vibevault.paymentgateway.exceptions.PaymentNotFoundException;
+import com.vibevault.paymentgateway.models.Payment;
+import com.vibevault.paymentgateway.models.PaymentStatus;
+import com.vibevault.paymentgateway.repositories.PaymentRepository;
+import com.vibevault.paymentgateway.services.paymentgateway.PaymentGateway;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentGatewaySelector paymentGatewaySelector;
+
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private PaymentLinkRequest buildRequest() {
+        return PaymentLinkRequest.builder()
+                .orderId(UUID.randomUUID())
+                .userId("user-1")
+                .amount(new BigDecimal("999.98"))
+                .currency("INR")
+                .build();
+    }
+
+    private Payment buildPayment(UUID id, PaymentStatus status) {
+        Payment payment = Payment.builder()
+                .orderId(UUID.randomUUID())
+                .userId("user-1")
+                .amount(new BigDecimal("999.98"))
+                .currency("INR")
+                .status(status)
+                .gateway("RAZORPAY")
+                .gatewayPaymentId("plink_test123")
+                .gatewayPaymentLink("https://rzp.io/test")
+                .orderEventId("event-1")
+                .build();
+        payment.setId(id);
+        return payment;
+    }
+
+    // --- createPayment ---
+
+    @Test
+    void createPayment_happyPath() {
+        PaymentLinkRequest request = buildRequest();
+        when(paymentRepository.findByOrderEventId("event-1")).thenReturn(Optional.empty());
+        when(paymentGatewaySelector.getPaymentGateway()).thenReturn(paymentGateway);
+        when(paymentGateway.getGatewayName()).thenReturn("RAZORPAY");
+        when(paymentGateway.createPaymentLink(request)).thenReturn(
+                PaymentLinkResponse.builder()
+                        .gatewayPaymentId("plink_123")
+                        .paymentLink("https://rzp.io/test")
+                        .gateway("RAZORPAY")
+                        .build());
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(i -> {
+            Payment p = i.getArgument(0);
+            if (p.getId() == null) p.setId(UUID.randomUUID());
+            return p;
+        });
+
+        Payment result = paymentService.createPayment(request, "event-1");
+
+        assertNotNull(result.getId());
+        assertEquals(PaymentStatus.PENDING, result.getStatus());
+        assertEquals("RAZORPAY", result.getGateway());
+        assertEquals("plink_123", result.getGatewayPaymentId());
+        verify(paymentRepository, times(2)).save(any()); // once for PENDING, once for link update
+    }
+
+    @Test
+    void createPayment_duplicate_returnsExisting() {
+        UUID existingId = UUID.randomUUID();
+        Payment existing = buildPayment(existingId, PaymentStatus.PENDING);
+        when(paymentRepository.findByOrderEventId("event-1")).thenReturn(Optional.of(existing));
+
+        Payment result = paymentService.createPayment(buildRequest(), "event-1");
+
+        assertEquals(existingId, result.getId());
+        verify(paymentGatewaySelector, never()).getPaymentGateway();
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void createPayment_nullOrderEventId_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> paymentService.createPayment(buildRequest(), null));
+    }
+
+    @Test
+    void createPayment_blankOrderEventId_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> paymentService.createPayment(buildRequest(), "  "));
+    }
+
+    // --- confirmPayment ---
+
+    @Test
+    void confirmPayment_pendingToConfirmed() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.PENDING);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+        when(paymentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        PaymentTransitionResult result = paymentService.confirmPayment("plink_test123");
+
+        assertTrue(result.stateChanged());
+        assertEquals(PaymentStatus.CONFIRMED, result.payment().getStatus());
+    }
+
+    @Test
+    void confirmPayment_alreadyConfirmed_noOp() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.CONFIRMED);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+
+        PaymentTransitionResult result = paymentService.confirmPayment("plink_test123");
+
+        assertFalse(result.stateChanged());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void confirmPayment_failedPayment_throws() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.FAILED);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+
+        assertThrows(InvalidPaymentStateException.class,
+                () -> paymentService.confirmPayment("plink_test123"));
+    }
+
+    // --- failPayment ---
+
+    @Test
+    void failPayment_pendingToFailed() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.PENDING);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+        when(paymentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        PaymentTransitionResult result = paymentService.failPayment("plink_test123", "expired");
+
+        assertTrue(result.stateChanged());
+        assertEquals(PaymentStatus.FAILED, result.payment().getStatus());
+        assertEquals("expired", result.payment().getFailureReason());
+    }
+
+    @Test
+    void failPayment_alreadyFailed_noOp() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.FAILED);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+
+        PaymentTransitionResult result = paymentService.failPayment("plink_test123", "expired");
+
+        assertFalse(result.stateChanged());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void failPayment_confirmedPayment_throws() {
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.CONFIRMED);
+        when(paymentRepository.findByGatewayPaymentId("plink_test123")).thenReturn(Optional.of(payment));
+
+        assertThrows(InvalidPaymentStateException.class,
+                () -> paymentService.failPayment("plink_test123", "expired"));
+    }
+
+    // --- getPaymentByOrderId ---
+
+    @Test
+    void getPaymentByOrderId_ownerAccess() {
+        UUID orderId = UUID.randomUUID();
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.PENDING);
+        payment.setOrderId(orderId);
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+        Payment result = paymentService.getPaymentByOrderId(orderId, "user-1");
+
+        assertEquals(orderId, result.getOrderId());
+    }
+
+    @Test
+    void getPaymentByOrderId_nonOwner_throws() {
+        UUID orderId = UUID.randomUUID();
+        Payment payment = buildPayment(UUID.randomUUID(), PaymentStatus.PENDING);
+        payment.setOrderId(orderId);
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.of(payment));
+
+        assertThrows(PaymentNotFoundException.class,
+                () -> paymentService.getPaymentByOrderId(orderId, "user-2"));
+    }
+
+    @Test
+    void getPaymentByOrderId_notFound_throws() {
+        UUID orderId = UUID.randomUUID();
+        when(paymentRepository.findByOrderId(orderId)).thenReturn(Optional.empty());
+
+        assertThrows(PaymentNotFoundException.class,
+                () -> paymentService.getPaymentByOrderId(orderId, "user-1"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.listener.auto-startup=false
+razorpay.key-id=test_key_id
+razorpay.key-secret=test_key_secret

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,4 @@ spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.listener.auto-startup=false
 razorpay.key-id=test_key_id
 razorpay.key-secret=test_key_secret
+razorpay.webhook-secret=test_webhook_secret


### PR DESCRIPTION
## Summary
- **13 PaymentService unit tests** (Mockito): create payment, idempotency, null/blank validation, confirm/fail state machine, owner access
- **4 PaymentController MockMvc tests**: GET by orderId, GET by paymentId, 404, 401
- **CI workflow**: PR to main, JDK 21, `./mvnw verify`
- **CD workflow**: manual trigger, Docker → ECR, Helm deploy with dynamic RDS endpoint
- Test config: H2 in-memory, Flyway disabled, Kafka auto-start disabled, mock JwtDecoder

## Test plan
- [x] All 18 tests pass with `./mvnw verify`
- [x] CI triggers on PRs
- [x] CD deploys to EKS

Closes #8